### PR TITLE
fix: adds resolver

### DIFF
--- a/nginx/nginx.service
+++ b/nginx/nginx.service
@@ -21,7 +21,7 @@ RestartSec=10s
 
 # filesystem access
 TemporaryFileSystem=/:ro
-BindReadOnlyPaths=/lib/ /lib64/ /usr/lib/ /usr/lib64/ /etc/ld.so.cache /etc/ld.so.conf /etc/ld.so.conf.d/ /etc/bindresvport.blacklist /usr/share/zoneinfo/ /usr/share/locale/ /etc/localtime /usr/share/common-licenses/ /etc/ssl/certs/
+BindReadOnlyPaths=/lib/ /lib64/ /usr/lib/ /usr/lib64/ /etc/ld.so.cache /etc/ld.so.conf /etc/ld.so.conf.d/ /etc/bindresvport.blacklist /usr/share/zoneinfo/ /usr/share/locale/ /etc/localtime /usr/share/common-licenses/ /etc/ssl/certs/ /etc/resolv.conf
 BindReadOnlyPaths=/dev/log /run/systemd/journal/socket /run/systemd/journal/stdout /run/systemd/notify
 BindReadOnlyPaths=/usr/sbin/nginx
 BindReadOnlyPaths=/run/ /path/to/webdir/ /path/to/certificates/


### PR DESCRIPTION
averts `host not found in upstream` error